### PR TITLE
Delay startup until after network-online.target

### DIFF
--- a/systemd/baksnapper@.timer
+++ b/systemd/baksnapper@.timer
@@ -1,5 +1,6 @@
 [Unit]
 Description=Run baksnapper@%i each night
+After=network-online.target
 
 [Timer]
 OnCalendar=00:20


### PR DESCRIPTION
Persistent=true makes baksnapper run on boot, but the service fails if configured to back up over ssh and DNS is not yet available.