### PR TITLE
Add check after initial send in backup function

### DIFF
--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -547,6 +547,12 @@ function backup {
         fi
     fi
 
+    # If source only contained one snapshot, then we are done.
+    if [ "$num_src_only" -eq 0 ]
+    then
+        return 0
+    fi
+
     if [[ $p_all == 0 ]]
     then
         local common_last=${common[${#common[@]}-1]}


### PR DESCRIPTION
That will exit the backup function if it is done after the initial
snapshot. Fixes the bug that baksnapper will fail when there only
exist one snapshot to backup.