### PR TITLE
Only fetch the last snapshot in the backup function

### DIFF
--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -401,13 +401,6 @@ case $receiver_version in
 esac
 num_dest_snapshots=${#dest_snapshots[@]}
 
-if [[ -z $p_snapshot ]]
-then
-    p_snapshot=${src_snapshots[num_src_snapshots-1]}
-else
-    $sender verify-snapshot "$src_root/$p_snapshot" || exit 1
-fi
-
 ################################################################################
 # Compare source and destination location and sort the snapshots into:
 # common: exist at both locations
@@ -504,6 +497,13 @@ function backup {
     if [[ $num_src_snapshots == 0 ]]
     then
         error "No snapshots found."
+    fi
+
+    if [[ -z $p_snapshot ]]
+    then
+        p_snapshot=${src_snapshots[num_src_snapshots-1]}
+    else
+        $sender verify-snapshot "$src_root/$p_snapshot" || exit 1
     fi
 
     local num_src_only=${#only_in_src[@]}


### PR DESCRIPTION
`p_snapshot` is only used in the backup function and there are edge case where the source snapshots can be empty and you want to prune the destination snapshots. Which will cause a bad array subscript.

Fetching the last snapshot in the backup function guarantees that there will be at least one source snapshot.

Fixes #16