### PR TITLE
Clean up interrupted snapshots

### DIFF
--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -481,7 +481,7 @@ function incremental-backup {
         error "Failed to send snapshot info!"
     fi
 
-    if ! $sender send-incremental-snapshot "$subvolume/.snapshots/"{"$1","$2"} \
+    if ! $sender send-incremental-snapshot "$src_root/"{"$1","$2"} \
             | $receiver receive-snapshot "$dest_root" "$2"
     then
         $receiver remove-broken-snapshot "$dest_root" "$1"

--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -597,7 +597,24 @@ function backup {
 }
 
 # Main:
-if [[ ${p_delete_all-0} == 1 ]]
+if [[ ${p_clean-0} == 1 ]]
+then
+    if [[ $receiver_version -lt 3 ]]
+    then
+        error "Daemon is too old, got version $receiver_version, need at least version 3."
+    fi
+    for snapshot in "${dest_snapshots[@]}"
+    do
+        if $receiver incomplete-snapshot "$dest_root" "$snapshot"
+        then
+            $receiver remove-broken-snapshot  "$dest_root" "$snapshot"
+        fi
+    done
+    if [[ $p_link -eq 1 ]]
+    then
+        $receiver link-latest "$dest_root"
+    fi
+elif [[ ${p_delete_all-0} == 1 ]]
 then
     echo -n "Are you sure you want to delete all backup snapshots from $dest_root? (y/N): "
     while true

--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -366,14 +366,14 @@ then
     sender_version=1
 fi
 
-if [[ "$receiver_version" -gt 2 ]]
+if [[ "$receiver_version" -gt 3 ]]
 then
-    error "receiver is too new, need to use version 2 or 1"
+    error "receiver is too new, need to use version 1-3"
 fi
 
-if [[ "$sender_version" -gt 2 ]]
+if [[ "$sender_version" -gt 3 ]]
 then
-    error "sender is too new, need to use version 2 or 1"
+    error "sender is too new, need to use version 1-3"
 fi
 
 # Get the subvolume to backup

--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -38,6 +38,9 @@ Options:
 
 --delete-all      Delete all backup snapshots for config
 
+--clean           Delete all incomplete backup snapshots for config.
+                  Use if backup got interrupted.
+
 --snapshot NUMBER Backup specific snapshot NUMBER, default is the last one.
 
 --type TYPE       Specify either to backup snapshots to a server
@@ -175,7 +178,24 @@ function read-config {
 
 # Use getopt to parse the command-line arguments
 
-if ! _args=$(getopt --name "baksnapper" --options "adhvp" --long "config:,configfile:,delete:,daemon:,private-key:,snapshot:,type:,all,delete-all,help,prune,verbose,version,link" -- "$@")
+if ! _args=$(getopt --name "baksnapper" \
+             --options "adhvp" \
+             --long config: \
+             --long configfile: \
+             --long delete: \
+             --long daemon: \
+             --long private-key: \
+             --long snapshot: \
+             --long type: \
+             --long all \
+             --long delete-all \
+             --long clean \
+             --long help \
+             --long prune \
+             --long verbose \
+             --long version \
+             --long link \
+             -- "$@")
 then
     error "Try '$0 --help for more information.'"
 fi
@@ -198,6 +218,9 @@ case $key in
     --configfile)
         read-config "$2"
         shift 2
+        ;;
+    --clean)
+        p_clean=1
         ;;
     --delete)
         p_delete=1

--- a/baksnapperd.sh
+++ b/baksnapperd.sh
@@ -43,6 +43,12 @@ case "$1" in
         shift
         find "$1" &> /dev/null || error "Snapshot $1 doesn't exist."
         ;;
+    incomplete-snapshot)
+        shift
+        [[ ! -f "$1/$2/info.xml" ]] || \
+        [[ ! -d "$1/$2/snapshot" ]] || \
+        [[ $(btrfs property get "$1/$2/snapshot" ro) != "ro=true" ]]
+        ;;
     create-config)
         shift
         mkdir -p "$1"

--- a/baksnapperd.sh
+++ b/baksnapperd.sh
@@ -29,7 +29,7 @@ function warning {
 
 case "$1" in
     version) # Return what version of the API it's using, always one integer
-        echo 2
+        echo 3
         ;;
     list-snapshots) # List snapshots at backup location
         shift


### PR DESCRIPTION
Add a new command `--clean` that will remove all snapshots at the receiver location that isn't read only, i.e. incomplete. As all snapper snapshots should be read only if valid. If they are writable that means everything didn't get sent.