### PR TITLE
Added a summary report 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ SPDX-FileCopyrightText: 2023 Fredrik Salomonsson <plattfot@posteo.net>
 
 SPDX-License-Identifier: GPL-3.0-or-later
 
+2025-06-01 Juergen Gleiss
+	Add summary report (#31), which prints destination, snapper ids,
+	bytes of data transfer, start time, end time and duration
+
 2025-01-04 Fredrik Salomonsson <plattfot@posteo.net>
 	* 2.3.0 :
 	Cleanup broken snapshots.


### PR DESCRIPTION
If the backup transfer was successful, statistics are displayed. The following values ​​are displayed in a table:

- dest_root: Backup destination
- src: None for the first backup, otherwise the snapper ID of the source
- dest: Snapper ID
- bytes: Total bytes of the transfer
- start: Unix timestamp indicating when the transfer began
- end: Unix timestamp indicating the end of the transfer
- duration: Duration of the data transfer

The columns are separated by tabular formatting