### PR TITLE
Add mock commands for btrfs and snapper

### DIFF
--- a/tests/bin/btrfs
+++ b/tests/bin/btrfs
@@ -1,0 +1,141 @@
+#! /usr/bin/env bash
+
+# Mock of the btrfs binary for testing
+
+# SPDX-FileCopyrightText: 2025  Fredrik Salomonsson <plattfot@posteo.net>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+read -rd '' help <<EOF
+Usage: btrfs [COMMAND] [OPTION]...
+
+Mock variant of the btrfs binary for testing
+
+Commands:
+  send
+  receive
+  subvolume
+  property
+
+Send options:
+  -p PARENT
+
+Subvolume commands:
+  delete
+
+Property commands:
+  get
+
+Author:
+Fredrik "PlaTFooT" Salomonsson
+EOF
+
+# Use getopt to parse the command-line arguments
+if ! _args=$(getopt --name btrfs \
+                    --options "hp:" \
+                    --long "help" \
+                    -- "$@")
+then
+    echo "Try '$0 --help for more information.'" >&2
+    exit 1
+fi
+
+eval set -- "$_args"
+# Parse options
+while [[ $# -gt 0 ]]
+do
+    key=$1
+    case $key in
+        -p)
+            parent=$2
+            shift 2
+            ;;
+        -h|--help)
+            echo -e "$help"
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+function subvolume {
+    case "$1" in
+        delete)
+            rm -rf -- "$1"
+            ;;
+        *)
+            >&2 echo "unsupported subcommand to subvolume: $1"
+            exit 1
+            ;;
+    esac
+}
+
+function send {
+    echo "$parent":"$1"
+}
+
+function receive {
+    read -r data
+    snapshot_parent=${data%:*}
+    if [[ -n "$snapshot_parent" ]]
+    then
+        snapshot_parent=$(basename "$(dirname "$snapshot_parent")")
+    fi
+    snapshot=${data#*:}
+
+    mkdir -p "$1/snapshot"
+    {
+        echo "parent=$snapshot_parent"
+        echo "snapshot=$snapshot"
+        echo "ro=true"
+    } > "$1/snapshot/data"
+}
+
+function property {
+    case "$1" in
+        get)
+            prop=$3
+            while read -r line; do
+                case $line in
+                    ${prop}*=*)
+                        if [[ "$line" =~ .*=[[:blank:]]*(.*) ]]
+                        then
+                            value="${BASH_REMATCH[1]}"
+                        fi
+                        ;;
+                    *)
+                        ;;
+                esac
+            done < "$2/data"
+            echo "${prop}=${value-false}"
+            ;;
+        *)
+            >&2 echo "unsupported subcommand to property: $1"
+            exit 1
+            ;;
+    esac
+}
+case "$1" in
+    subvolume)
+        shift 1
+        subvolume "$@"
+        ;;
+    receive)
+        shift 1
+        receive "$@"
+        ;;
+    send)
+        shift 1
+        send "$@"
+        ;;
+    property)
+        shift 1
+        property "$@"
+        ;;
+    *)
+        >&2 echo "unsupported command: $1"
+        exit 1
+esac

--- a/tests/bin/snapper
+++ b/tests/bin/snapper
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Mock of the snapper binary for testing
+
+# SPDX-FileCopyrightText: 2025  Fredrik Salomonsson <plattfot@posteo.net>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+read -rd '' help <<EOF
+Usage: snapper [COMMAND] [OPTION]...
+
+Mock variant of the snapper binary for testing
+
+Commands:
+  get-config
+
+Options:
+  --no-dbus
+  -c CONFIG
+
+Author:
+Fredrik "PlaTFooT" Salomonsson
+EOF
+
+# Use getopt to parse the command-line arguments
+if ! _args=$(getopt --name btrfs \
+                    --options "hc:" \
+                    --long "help" \
+                    --long "no-dbus" \
+                    -- "$@")
+then
+    echo "Try '$0 --help for more information.'" >&2
+    exit 1
+fi
+
+eval set -- "$_args"
+# Parse options
+while [[ $# -gt 0 ]]
+do
+    key=$1
+    case $key in
+        -c)
+            config=$2
+            shift 2
+            ;;
+        -h|--help)
+            echo -e "$help"
+            exit 0
+            ;;
+        --no-dbus)
+            shift 1
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+if [[ -z "$BAKSNAPPER_TEST_RUNNER_SENDER_ROOT" ]]
+then
+    >&2 echo "snapper mock: BAKSNAPPER_TEST_RUNNER_SENDER_ROOT is not set"
+    exit 1
+fi
+
+cat <<EOF
+Key                    │ Value
+───────────────────────┼─────────
+ALLOW_GROUPS           │
+ALLOW_USERS            │
+BACKGROUND_COMPARISON  │ yes
+EMPTY_PRE_POST_CLEANUP │ yes
+EMPTY_PRE_POST_MIN_AGE │ 1800
+FSTYPE                 │ btrfs
+NUMBER_CLEANUP         │ yes
+NUMBER_LIMIT           │ 50
+NUMBER_LIMIT_IMPORTANT │ 10
+NUMBER_MIN_AGE         │ 1800
+SUBVOLUME              │ $BAKSNAPPER_TEST_RUNNER_SENDER_ROOT/$config
+SYNC_ACL               │ no
+TIMELINE_CLEANUP       │ yes
+TIMELINE_CREATE        │ yes
+TIMELINE_LIMIT_DAILY   │ 3
+TIMELINE_LIMIT_HOURLY  │ 0
+TIMELINE_LIMIT_MONTHLY │ 2
+TIMELINE_LIMIT_YEARLY  │ 0
+TIMELINE_MIN_AGE       │ 1800
+EOF


### PR DESCRIPTION
These will allow tests to run without needing to have `snapper` or `btrfs` setup.

- `snapper`: will just return the output `baksnapperd` expects to parse the config for. The script expects the environment variable `BAKSNAPPER_TEST_RUNNER_SENDER_ROOT` to be set and points to where the root directory is for the sender.
- `btrfs`: This will just generate a pseudo snapper snapshot when receiving one. Where it will just create an empty info.xml and a directory named `snapshot` with a text file `data` that just contains key-value pairs that describes the snapshot. Things that a test runner then can parse and see if things line up with what it expects.