### PR TITLE
Add a test runner

### DIFF
--- a/baksnapperd.sh
+++ b/baksnapperd.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Baksnapperd - Daemon used by baksnapper when backup via ssh
 

--- a/build-aux/version
+++ b/build-aux/version
@@ -1,0 +1,72 @@
+#! /usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025  Fredrik Salomonsson <plattfot@posteo.net>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+major=2
+minor=3
+patch=0
+
+version=$major.$minor.$patch
+
+read -rd '' help <<EOF
+Usage: $0 [OPTIONS...]
+
+Print version information.  Default it will print the whole version.
+
+Options:
+
+-h, --help   Print this help and then exit.
+-s, --short  Print only the major minor version.
+-M, --major  Print only major version
+-m, --minor  Print only minor version
+-p, --patch  Print only patch version
+
+EOF
+
+if ! _args=$(getopt --name "version" \
+             --options "hmMps" \
+             --long help \
+             --long major \
+             --long minor \
+             --long patch \
+             --long mm \
+             -- "$@")
+then
+    error "Try '$0 --help for more information.'"
+fi
+
+# Parse options
+while [[ $# -gt 0 ]]
+do
+key=$1
+case $key in
+    -s|--short)
+        version=$major.$minor
+        shift
+        ;;
+    -M|--major)
+        version=$major
+        shift
+        ;;
+    -m|--minor)
+        version=$minor
+        shift
+        ;;
+    -p|--patch)
+        version=$patch
+        shift
+        ;;
+    -h|--help)
+        echo -e "$help"
+        exit 0
+        ;;
+    --)
+        shift
+        break
+        ;;
+esac
+done
+
+echo $version

--- a/guix.scm
+++ b/guix.scm
@@ -1,0 +1,51 @@
+; SPDX-FileCopyrightText: 2025 Fredrik Salomonsson <plattfot@posteo.net>
+;
+; SPDX-License-Identifier: GPL-3.0-or-later
+
+(use-modules
+  (gnu packages bash)
+  (gnu packages base)
+  (gnu packages linux)
+  (gnu packages)
+  ((guix licenses) #:prefix license:)
+  (guix build-system meson)
+  (guix download)
+  (guix gexp)
+  (guix git-download)
+  (guix packages)
+  (guix utils)
+  (ice-9 popen)
+  (ice-9 rdelim))
+
+;; From the talk "Just build it with Guix" by Efraim Flashner
+;; presented on the Guix days 2020
+;; https://guix.gnu.org/en/blog/2020/online-guix-day-announce-2/
+(define %source-dir (current-source-directory))
+
+(define %git-commit
+  (read-string (open-pipe "git show HEAD | head -1 | cut -d ' ' -f2" OPEN_READ)))
+
+(define (skip-git-and-meson-artifacts file stat)
+  "Skip git and autotools artifacts when collecting the sources."
+  (let ((name (substring file (+ 1 (string-prefix-length %source-dir file)))))
+    (not (or (string=? name ".envrc")
+             (string-prefix? "./build" name)
+             ))))
+
+(define-public baksnapper
+  (package
+    (name "baksnapper")
+    (version (git-version "2.3.0" "HEAD" %git-commit))
+    (source (local-file %source-dir
+                        #:recursive? #t
+                        #:select? skip-git-and-meson-artifacts))
+    (build-system meson-build-system)
+    (inputs (list bash util-linux))
+    (synopsis "Backup tool for snapper")
+    (description
+     "Baksnapper is a script for backing up snapshots created by the program
+snapper using btrfs send and receive.")
+    (home-page "")
+    (license license:gpl3+)))
+
+baksnapper

--- a/guix.scm
+++ b/guix.scm
@@ -25,6 +25,9 @@
 (define %git-commit
   (read-string (open-pipe "git show HEAD | head -1 | cut -d ' ' -f2" OPEN_READ)))
 
+(define %package-version
+  (string-trim-right (read-string (open-pipe "./build-aux/version" OPEN_READ))))
+
 (define (skip-git-and-meson-artifacts file stat)
   "Skip git and autotools artifacts when collecting the sources."
   (let ((name (substring file (+ 1 (string-prefix-length %source-dir file)))))
@@ -35,7 +38,7 @@
 (define-public baksnapper
   (package
     (name "baksnapper")
-    (version (git-version "2.3.0" "HEAD" %git-commit))
+    (version (git-version %package-version "HEAD" %git-commit))
     (source (local-file %source-dir
                         #:recursive? #t
                         #:select? skip-git-and-meson-artifacts))

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 
 project(
   'baksnapper',
-  version: '2.3.0'
+  version: run_command('./build-aux/version', check: true).stdout().strip()
 )
 
 install_cmd = find_program('install')

--- a/meson.build
+++ b/meson.build
@@ -74,3 +74,25 @@ test(
   baksnapper,
   args: ['--help'],
 )
+
+test_env = environment()
+test_env.prepend('PATH', meson.current_source_dir() / 'tests/bin')
+runner = find_program('./tests/runner.scm')
+
+test(
+  'default',
+  runner,
+  env: test_env,
+  args: [
+    '--sender', '1,2,3',
+    '--expected', '3',
+    '--',
+    baksnapper[0].full_path(),
+    '--config', 'root',
+    '--daemon', baksnapperd[0].full_path(),
+  ],
+  depends: [
+    baksnapper,
+    baksnapperd,
+  ],
+)

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project(
 
 install_cmd = find_program('install')
 
-custom_target(
+baksnapper = custom_target(
   command: [install_cmd, '@INPUT@', '@OUTPUT@'],
   input: 'baksnapper.sh',
   output: 'baksnapper',
@@ -67,4 +67,10 @@ install_data(
   rename: 'root.bsconf',
   install_dir: get_option('sysconfdir')/'baksnapper/example',
   install_tag: 'runtime',
+)
+
+test(
+  'help',
+  baksnapper,
+  args: ['--help'],
 )

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ custom_target(
   install_tag: 'runtime',
 )
 
-custom_target(
+baksnapperd = custom_target(
   command: [install_cmd, '@INPUT@', '@OUTPUT@'],
   input: 'baksnapperd.sh',
   output: 'baksnapperd',

--- a/tests/bin/btrfs
+++ b/tests/bin/btrfs
@@ -1,0 +1,141 @@
+#! /usr/bin/env bash
+
+# Mock of the btrfs binary for testing
+
+# SPDX-FileCopyrightText: 2025  Fredrik Salomonsson <plattfot@posteo.net>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+read -rd '' help <<EOF
+Usage: btrfs [COMMAND] [OPTION]...
+
+Mock variant of the btrfs binary for testing
+
+Commands:
+  send
+  receive
+  subvolume
+  property
+
+Send options:
+  -p PARENT
+
+Subvolume commands:
+  delete
+
+Property commands:
+  get
+
+Author:
+Fredrik "PlaTFooT" Salomonsson
+EOF
+
+# Use getopt to parse the command-line arguments
+if ! _args=$(getopt --name btrfs \
+                    --options "hp:" \
+                    --long "help" \
+                    -- "$@")
+then
+    echo "Try '$0 --help for more information.'" >&2
+    exit 1
+fi
+
+eval set -- "$_args"
+# Parse options
+while [[ $# -gt 0 ]]
+do
+    key=$1
+    case $key in
+        -p)
+            parent=$2
+            shift 2
+            ;;
+        -h|--help)
+            echo -e "$help"
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+function subvolume {
+    case "$1" in
+        delete)
+            rm -rf -- "$1"
+            ;;
+        *)
+            >&2 echo "unsupported subcommand to subvolume: $1"
+            exit 1
+            ;;
+    esac
+}
+
+function send {
+    echo "$parent":"$1"
+}
+
+function receive {
+    read -r data
+    snapshot_parent=${data%:*}
+    if [[ -n "$snapshot_parent" ]]
+    then
+        snapshot_parent=$(basename "$(dirname "$snapshot_parent")")
+    fi
+    snapshot=${data#*:}
+
+    mkdir -p "$1/snapshot"
+    {
+        echo "parent=$snapshot_parent"
+        echo "snapshot=$snapshot"
+        echo "ro=true"
+    } > "$1/snapshot/data"
+}
+
+function property {
+    case "$1" in
+        get)
+            prop=$3
+            while read -r line; do
+                case $line in
+                    ${prop}*=*)
+                        if [[ "$line" =~ .*=[[:blank:]]*(.*) ]]
+                        then
+                            value="${BASH_REMATCH[1]}"
+                        fi
+                        ;;
+                    *)
+                        ;;
+                esac
+            done < "$2/data"
+            echo "${prop}=${value-false}"
+            ;;
+        *)
+            >&2 echo "unsupported subcommand to property: $1"
+            exit 1
+            ;;
+    esac
+}
+case "$1" in
+    subvolume)
+        shift 1
+        subvolume "$@"
+        ;;
+    receive)
+        shift 1
+        receive "$@"
+        ;;
+    send)
+        shift 1
+        send "$@"
+        ;;
+    property)
+        shift 1
+        property "$@"
+        ;;
+    *)
+        >&2 echo "unsupported command: $1"
+        exit 1
+esac

--- a/tests/bin/snapper
+++ b/tests/bin/snapper
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Mock of the snapper binary for testing
+
+# SPDX-FileCopyrightText: 2025  Fredrik Salomonsson <plattfot@posteo.net>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+read -rd '' help <<EOF
+Usage: snapper [COMMAND] [OPTION]...
+
+Mock variant of the snapper binary for testing
+
+Commands:
+  get-config
+
+Options:
+  --no-dbus
+  -c CONFIG
+
+Author:
+Fredrik "PlaTFooT" Salomonsson
+EOF
+
+# Use getopt to parse the command-line arguments
+if ! _args=$(getopt --name btrfs \
+                    --options "hc:" \
+                    --long "help" \
+                    --long "no-dbus" \
+                    -- "$@")
+then
+    echo "Try '$0 --help for more information.'" >&2
+    exit 1
+fi
+
+eval set -- "$_args"
+# Parse options
+while [[ $# -gt 0 ]]
+do
+    key=$1
+    case $key in
+        -c)
+            config=$2
+            shift 2
+            ;;
+        -h|--help)
+            echo -e "$help"
+            exit 0
+            ;;
+        --no-dbus)
+            shift 1
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+if [[ -z "$BAKSNAPPER_TEST_RUNNER_SENDER_ROOT" ]]
+then
+    >&2 echo "snapper mock: BAKSNAPPER_TEST_RUNNER_SENDER_ROOT is not set"
+    exit 1
+fi
+
+cat <<EOF
+Key                    │ Value
+───────────────────────┼─────────
+ALLOW_GROUPS           │
+ALLOW_USERS            │
+BACKGROUND_COMPARISON  │ yes
+EMPTY_PRE_POST_CLEANUP │ yes
+EMPTY_PRE_POST_MIN_AGE │ 1800
+FSTYPE                 │ btrfs
+NUMBER_CLEANUP         │ yes
+NUMBER_LIMIT           │ 50
+NUMBER_LIMIT_IMPORTANT │ 10
+NUMBER_MIN_AGE         │ 1800
+SUBVOLUME              │ $BAKSNAPPER_TEST_RUNNER_SENDER_ROOT/$config
+SYNC_ACL               │ no
+TIMELINE_CLEANUP       │ yes
+TIMELINE_CREATE        │ yes
+TIMELINE_LIMIT_DAILY   │ 3
+TIMELINE_LIMIT_HOURLY  │ 0
+TIMELINE_LIMIT_MONTHLY │ 2
+TIMELINE_LIMIT_YEARLY  │ 0
+TIMELINE_MIN_AGE       │ 1800
+EOF

--- a/tests/runner.scm
+++ b/tests/runner.scm
@@ -11,6 +11,7 @@
              (ice-9 getopt-long)
              (ice-9 hash-table)
              (ice-9 match)
+             (ice-9 popen)
              (ice-9 textual-ports)
              (srfi srfi-1)
              (srfi srfi-2)
@@ -308,9 +309,14 @@ Fredrik \"PlaTFooT\" Salomonsson
             (path-join receiver-dir (snapshot-id snapshot))
             snapshot))
          receiver-snapshots)
-        ;; Run command
 
-        (format #t "running command: ~a~%" command)
+        ;; Run command
+        (let ((command-with-path (append command (list receiver-root-dir))))
+          (format #t "Running command: ~a…~%" command-with-path)
+          (setenv "BAKSNAPPER_TEST_RUNNER_SENDER_ROOT" test-dir)
+          (let ((pipe (apply open-pipe* OPEN_READ command-with-path)))
+            (format #t "~a~%" (get-string-all pipe))
+            (set! exit-status (status:exit-val (close-pipe pipe)))))
 
         ;; Check
         (let* ((result-snapshots

--- a/tests/runner.scm
+++ b/tests/runner.scm
@@ -273,7 +273,8 @@ Fredrik \"PlaTFooT\" Salomonsson
       (format #t "  sender:   ~a~%" sender)
       (format #t "  receiver: ~a~%" receiver)
       (format #t "  expected: ~a~%" expected)
-      (let ((sender-snapshots
+      (let ((exit-status 0)
+            (sender-snapshots
              (map (lambda (id)
                     (make-snapshot id #f 'valid))
                   sender))
@@ -328,5 +329,6 @@ Fredrik \"PlaTFooT\" Salomonsson
                       filename
                       statinfo)))
                 #t)
-              'depth)))))
+              'depth)
+        (exit exit-status)))))
 

--- a/tests/runner.scm
+++ b/tests/runner.scm
@@ -1,0 +1,101 @@
+#! /usr/bin/env -S guile --no-auto-compile -e main -s
+!#
+; Script to run a baksnapper test
+
+; SPDX-FileCopyrightText: 2025  Fredrik Salomonsson <plattfot@posteo.net>
+;
+; SPDX-License-Identifier: GPL-3.0-or-later
+
+(use-modules (ice-9 format)
+             (ice-9 getopt-long)
+             (ice-9 match)
+             (srfi srfi-1)
+             (srfi srfi-2)
+             (srfi srfi-9))
+
+(define* (path-join #:key (separator file-name-separator-string) . paths)
+  "Join PATHS into one path using `file-name-separator-string`."
+  (string-join paths file-name-separator-string))
+
+(define (main args)
+  (let* ((option-spec
+          `((config (single-char #\c) (value #t))
+            (sender (single-char #\s) (value #t))
+            (receiver (single-char #\r) (value #t))
+            (expected (single-char #\e) (value #t))
+            (type (single-char #\t) (value #t))
+            (help (single-char #\h) (value #f))))
+         (options (getopt-long args option-spec))
+         (exec-name (car args))
+         (try-help (format #f "Try '~a --help' for more information.~%" exec-name)))
+    (when (option-ref options 'help #f)
+      (format #t "\
+Usage: ~a [OPTION]... -- [COMMAND] [OPTION]...
+
+Run a baksnapper test based on the options.  It has three sections.
+The setup stage, running the baksnapper command and expected result.
+If test succeeds it will clean up the setup.
+
+By default it will generate the test setup in a temporary directory in
+the temp directory.
+
+Options:
+  -c, --config   CONFIG     Name of the snapper config.
+  -s, --sender   S0[,S1,…]  Snapshots at the source it should create.
+  -r, --receiver R0[:RM0][,R1[:RM1],…]  Snapshots at the destination.
+  -e, --expected E0[:EM0][,E1[:EM1],…]  Snapshots expected after running baksnapper.
+  -t, --type TYPE           Snapshot type, default is snapper.
+
+Where SN, RN and EN are name of snapshots at the respective
+location/stage.  RMN and EMN are metadata associated with a snapshot
+for before and after after running baksnapper at the receiving
+location.  Supported metadata are s=STATE which sets the state for the
+snapshot.
+
+It accept the following:
+- valid: A complete snapshot.
+- empty: A broken snapshot that's empty.
+- no-snapshot: For snapper — Missing the snapshot subdirectory.
+- no-info: For snapper — Missing the info.xml file.
+- incomplete: An incomplete snapshot.
+
+And p=PARENT, which list the parent of the snapshot.
+
+The metadata are separate with :.
+
+For example snapshot 10 with an incomplete state and parent snapshot
+9.  Would be listed as `10:s=incomplete:p=9`.
+
+Author:
+Fredrik \"PlaTFooT\" Salomonsson
+"
+              exec-name)
+      (exit #t))
+    (let* ((parse-comma-option
+            (lambda (input)
+              (remove string-null? (string-split (option-ref options input "")  #\,))))
+           (config (option-ref options 'config "root"))
+           (sender (parse-comma-option 'sender))
+           (receiver (parse-comma-option 'receiver))
+           (expected (parse-comma-option 'expected))
+           (command (option-ref options '() '()))
+           (test-dir (mkdtemp (path-join
+                               (string-trim-right (or (getenv "TEMP") "/tmp") #\/)
+                               "baksnapper-test-XXXXXX")))
+           (sender-dir (path-join test-dir config ".snapshots"))
+           (receiver-root-dir (path-join test-dir "receiver"))
+           (receiver-dir (path-join receiver-root-dir config)))
+      (format #t "Test ~a~%" test-dir)
+      (format #t "  sender:   ~a~%" sender)
+      (format #t "  receiver: ~a~%" receiver)
+      (format #t "  expected: ~a~%" expected)
+      (format #t "  verify: ~a~%" (check-snapshot-input "10:s=valid:p=9"))
+      ;; (mkdir sender-dir)
+      ;; (for-each
+      ;;  (lambda (snapshot)
+      ;;    (create-snapper-snapshot (string-append sender-dir "/" snapshot) 'valid))
+      ;;  sender)
+      ;; TODO: parse state for receiver and expected snapshots
+      ;; (rmdir test-dir)
+      )))
+

--- a/tests/runner.scm
+++ b/tests/runner.scm
@@ -17,6 +17,13 @@
   "Join PATHS into one path using `file-name-separator-string`."
   (string-join paths file-name-separator-string))
 
+(define-record-type <snapshot>
+  (make-snapshot id parent state)
+  snapshot?
+  (id snapshot-id)
+  (parent snapshot-parent)
+  (state snapshot-state))
+
 (define (main args)
   (let* ((option-spec
           `((config (single-char #\c) (value #t))

--- a/tests/runner.scm
+++ b/tests/runner.scm
@@ -24,6 +24,30 @@
   (parent snapshot-parent)
   (state snapshot-state))
 
+(define (make-snapshot-from input)
+  "Parse INPUT and create a snapshot from it."
+  (let* ((info (string-split input #\:))
+         (id (car info))
+         (metadata
+          (map
+           (lambda (metadatum)
+             (match (string-split metadatum #\=)
+              (("p" parent) (cons 'parent parent))
+              (("s" state)
+               (let ((state-sym (string->symbol state)))
+                 (match state-sym
+                    ((or 'valid 'empty 'no-info 'no-snapshot 'incomplete)
+                     (cons 'state state-sym)))))))
+           (cdr info))))
+    (make-snapshot
+     id
+     (match (assoc 'parent metadata)
+       (('parent . p) p)
+       (_ #f))
+     (match (assoc 'state metadata)
+       (('state . s) s)
+       (_ 'valid)))))
+
 (define (create-snapper-snapshot path snapshot)
   "Create dummy snapper snapshot at PATH for SNAPSHOT.
 


### PR DESCRIPTION
Add a `test/runner.scm` which will setup a mock sender and receiver directories.  Call a command — which is expected to be `baksnapper` — then check if the resulting receiver directory matches the expected directory.

Also added one test for the default behavior when calling `baksnapper` with the minimum number of arguments. And things seems to be working.