### PR TITLE
bugfix: latest link won't be created in all cases.

### DIFF
--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -736,4 +736,3 @@ fi
 echo "--- Statistics ---"
 cat "${p_summary}"
 echo "--- Statistics ---"
-rm -rf "${p_temp_dir}"

--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -695,10 +695,6 @@ case $p_command in
         ;;
     delete)
         $receiver remove-snapshots "$dest_root" "${p_delete_list[@]}"
-        if [[ $p_link -eq 1 ]]
-        then
-            $receiver link-latest "$dest_root"
-        fi
         ;;
     delete-all)
         echo -n "Are you sure you want to delete all backup snapshots from $dest_root? (y/N): "
@@ -730,10 +726,14 @@ esac
 if [[ ${p_prune-0} == 1 ]]
 then
     $receiver remove-snapshots "$dest_root" "${only_in_dest[@]}"
-    if [[ $p_link -eq 1 ]]
-    then
-        $receiver link-latest "$dest_root"
-    fi
 fi
 
+if [[ $p_link -eq 1 ]]
+then
+    $receiver link-latest "$dest_root"
+fi
+
+echo "--- Statistics ---"
 cat "${p_summary}"
+echo "--- Statistics ---"
+rm -rf "${p_temp_dir}"

--- a/baksnapperd.sh
+++ b/baksnapperd.sh
@@ -129,12 +129,14 @@ case "$1" in
         fi
         for dir in $(find "$1" -maxdepth 1 -mindepth 1 -type d -printf "%P\n"|sort --version-sort)
         do
-            if [[ -d "$dir/snapshot" && ! -h "$dir" ]]; then
+            if [[ -d "$1/$dir/snapshot" && ! -h "$1/$dir" ]]; then
                 snapshots+=("$dir")
             fi
         done
-        if ! [ ${#snapshots[@]} -eq 0 ]; then
+        if  [ ${#snapshots[@]} -ne 0 ]; then
             ln -sfn "${snapshots[-1]}" "$1/latest"
+        else
+            error "link-latest: No suitable snapshots at $1 (${#snapshots[@]})"
         fi
         ;;
     test-connection)


### PR DESCRIPTION
**baksnapper.sh**
I've moved the 'link latest' creation to the end. 

**baksnapperd.sh**
On my systems the latest link won't be created in all cases. Thus I've added the absolute path to the checks.