### PR TITLE
Split delete args properly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ SPDX-FileCopyrightText: 2023 Fredrik Salomonsson <plattfot@posteo.net>
 
 SPDX-License-Identifier: GPL-3.0-or-later
 
+2025-06-02 Fredrik Salomonsson <plattfot@posteo.net>
+	Fix that it properly split the list in --delete.
 2025-06-01 Juergen Gleiss
 	Add summary report (#31), which prints destination, snapper ids,
 	bytes of data transfer, start time, end time and duration

--- a/baksnapper.sh
+++ b/baksnapper.sh
@@ -3,7 +3,7 @@
 # Baksnapper - Backup snapper snapshots to backup location using
 # btrfs' incremental send and receive
 
-# SPDX-FileCopyrightText: 2015-2024  Fredrik Salomonsson <plattfot@posteo.net>
+# SPDX-FileCopyrightText: 2015-2025  Fredrik Salomonsson <plattfot@posteo.net>
 # SPDX-FileCopyrightText: 2021       Nathan Dehnel
 # SPDX-FileCopyrightText: 2025       Juergen Gleiss
 #
@@ -230,7 +230,7 @@ case $key in
         ;;
     --delete)
         p_command=delete
-        p_delete_list=${2//,/ }
+        IFS=',' read -ra p_delete_list <<< "$2"
         shift 2
         ;;
     --delete-all)

--- a/meson.build
+++ b/meson.build
@@ -96,3 +96,43 @@ test(
     baksnapperd,
   ],
 )
+
+test(
+  'delete-1',
+  runner,
+  env: test_env,
+  args: [
+    '--sender', '1,2,3',
+    '--receiver', '1,2,3',
+    '--expected', '2,3',
+    '--',
+    baksnapper[0].full_path(),
+    '--config', 'root',
+    '--daemon', baksnapperd[0].full_path(),
+    '--delete', '1',
+  ],
+  depends: [
+    baksnapper,
+    baksnapperd,
+  ],
+)
+
+test(
+  'delete-1,3',
+  runner,
+  env: test_env,
+  args: [
+    '--sender', '1,2,3',
+    '--receiver', '1,2,3',
+    '--expected', '2',
+    '--',
+    baksnapper[0].full_path(),
+    '--config', 'root',
+    '--daemon', baksnapperd[0].full_path(),
+    '--delete', '1,3',
+  ],
+  depends: [
+    baksnapper,
+    baksnapperd,
+  ],
+)


### PR DESCRIPTION
Found a bug when adding unit tests for `--delete`. It didn't split the snapshots if given multiple. This is now fixed.