### PR TITLE
build: Set `latest` test to expect it to fail

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -115,6 +115,8 @@ test(
     baksnapper,
     baksnapperd,
   ],
+  # FIXME: remove once https://github.com/plattfot/baksnapper/pull/35 is merged
+  should_fail: true,
 )
 
 


### PR DESCRIPTION
Was too quick on the trigger finger when merging this.  I forgot I was testing this with the patches for #35.  Set this to fail until that is merged.