### PR TITLE
Release 2.6.0

### DIFF
--- a/CHANGELOG.d/20251126T213311--set-version-from-mesonmake__changed.md
+++ b/CHANGELOG.d/20251126T213311--set-version-from-mesonmake__changed.md
@@ -1,4 +1,0 @@
-<!-- SPDX-FileCopyrightText: 2025 Fredrik Salomonsson <plattfot@posteo.net> -->
-<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
-### Changed
-- Set version in scripts using meson/make. [#52](https://github.com/plattfot/baksnapper/issues/52)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Unreleased entries are located in [CHANGELOG.d](./CHANGELOG.d).
 
-## [2.4.1] - 2025-11-16
+## [2.5.0] - 2025-11-16
 ### Added
 - Interface to specify `SOURCE` and `DEST` explicitly.
 - `--source SOURCE` option, to override `SOURCE=` in configfile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Unreleased entries are located in [CHANGELOG.d](./CHANGELOG.d).
 
+## [2.6.0] - 2025-11-26
+### Changed
+- Set version in scripts using meson/make. [#52](https://github.com/plattfot/baksnapper/issues/52)
+
 ## [2.5.0] - 2025-11-16
 ### Added
 - Interface to specify `SOURCE` and `DEST` explicitly.

--- a/build-aux/version
+++ b/build-aux/version
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-version=2.5.0
+version=2.6.0
 
 read -rd '' help <<EOF
 Usage: $0 [OPTIONS...]


### PR DESCRIPTION
Which includes the fix for `--version` showing the right version for all scripts.